### PR TITLE
isup, mtp3: Use const char* whenever possible.

### DIFF
--- a/isup.c
+++ b/isup.c
@@ -5258,7 +5258,7 @@ void isup_show_calls(struct ss7 *ss7, ss7_printf_cb cust_printf, int fd)
 	free(tmp_buf);
 }
 
-int ss7_set_isup_timer(struct ss7 *ss7, char *name, int ms)
+int ss7_set_isup_timer(struct ss7 *ss7, const char *name, int ms)
 {
 	if (!strcasecmp(name, "t1")) {
 		ss7->isup_timers[ISUP_TIMER_T1] = ms;

--- a/libss7.h
+++ b/libss7.h
@@ -518,10 +518,10 @@ const char *ss7_get_version(void);
 
 int ss7_pollflags(struct ss7 *ss7, int fd);
 
-int ss7_set_mtp3_timer(struct ss7 *ss7, char *name, int ms);
+int ss7_set_mtp3_timer(struct ss7 *ss7, const char *name, int ms);
 
 /* ISUP call related message functions */
-int ss7_set_isup_timer(struct ss7 *ss7, char *name, int ms);
+int ss7_set_isup_timer(struct ss7 *ss7, const char *name, int ms);
 
 struct isup_call * isup_free_call_if_clear(struct ss7 *ss7, struct isup_call *c);
 
@@ -675,7 +675,7 @@ const char * mtp3_net_mng(struct ss7 *ss7, unsigned int slc, const char *cmd, un
 
 void mtp3_init_restart(struct ss7 *ss7, int slc);
 
-int ss7_set_mtp3_timer(struct ss7 *ss7, char *name, int ms);
+int ss7_set_mtp3_timer(struct ss7 *ss7, const char *name, int ms);
 
 void ss7_pc_to_str(int ss7type, unsigned int pc, char *str);
 

--- a/mtp3.c
+++ b/mtp3.c
@@ -2032,7 +2032,7 @@ const char * mtp3_net_mng(struct ss7 *ss7, unsigned int slc, const char *cmd, un
 	return "OK\n";
 }
 
-int ss7_set_mtp3_timer(struct ss7 *ss7, char *name, int ms)
+int ss7_set_mtp3_timer(struct ss7 *ss7, const char *name, int ms)
 {
 	if (!strcasecmp(name, "t1")) {
 		ss7->mtp3_timers[MTP3_TIMER_T1] = ms;


### PR DESCRIPTION
Use const char* instead of char* if we can, so that applications don't need to cast arguments to char* with gcc 15.2.1 (to avoid discarded-qualifiers errors).

Resolves: #4