### PR TITLE
ss7.c: Use poll.h instead of sys/poll.h.

### DIFF
--- a/ss7.c
+++ b/ss7.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include <time.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include "libss7.h"
 #include "ss7_internal.h"
 #include "mtp2.h"

--- a/ss7linktest.c
+++ b/ss7linktest.c
@@ -36,7 +36,7 @@
 #include <unistd.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/ioctl.h>
 #include <pthread.h>
 #include <errno.h>


### PR DESCRIPTION
Use poll.h for musl compatiblity.

Resolves: #6